### PR TITLE
removing the "Terminology Resources" and increasing the font f

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -141,17 +141,6 @@
                         </Box>
                     </Box>
 
-                    <Typography
-                        variant="h4"
-                        my={4}
-                        textAlign={"center"}
-                        fontWeight={"bold"}
-                        marginBottom={"1spx"}
-                    >
-                        {" "}
-                        Terminology Resources{" "}
-                    </Typography>
-
                     <Box sx={{ width: "100%", typography: "body1" }}>
                         <TabContext value={activeTab}>
                             <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
@@ -170,7 +159,7 @@
                                 <Box
                                     sx={{ flexGrow: "1", display: "flex", flexDirection: "column" }}
                                 >
-                                    <Typography variant="h5">Concept Domains</Typography>
+                                    <Typography variant="h4">Concept Domains</Typography>
                                     <Box
                                         sx={{
                                             display: "grid",
@@ -242,14 +231,14 @@
                                 <Box
                                     sx={{ flexGrow: "1", display: "flex", flexDirection: "column" }}
                                 >
-                                    <Typography variant="h5">Sources</Typography>
+                                    <Typography variant="h4">Sources</Typography>
                                 </Box>
                             </TabPanel>
                             <TabPanel value="3">
                                 <Box
                                     sx={{ flexGrow: "1", display: "flex", flexDirection: "column" }}
                                 >
-                                    <Typography variant="h5">Collections</Typography>
+                                    <Typography variant="h4">Collections</Typography>
                                 </Box>
                             </TabPanel>
                         </TabContext>

--- a/pages/index.js
+++ b/pages/index.js
@@ -245,7 +245,7 @@
                     </Box>
 
                     <Box
-                        style={{ backgroundColor: "#121212" }}
+                        style={{ backgroundColor: "#1651B6" }}
                         borderRadius={"8px"}
                         sx={{
                             display: "flex",

--- a/pages/index.js
+++ b/pages/index.js
@@ -150,9 +150,7 @@
                                     variant="standard"
                                     aria-label="lab API tabs example"
                                 >
-                                    <Tab label="Concept Domains" value="1" />
-                                    <Tab label="Sources" value="2" />
-                                    <Tab label="Collections" value="3" />
+                                    <Tab label="Concept Domains" value="1" />                            
                                 </TabList>
                             </Box>
                             <TabPanel value="1">


### PR DESCRIPTION
This pr--> 

Removes the "Terminology Resources" and increasing the font for better display as suggested 

[](https://github.com/orgs/moh-kenya/projects/30?pane=issue&itemId=51720418)

![image](https://github.com/moh-kenya/nhdd-frontend/assets/130601439/d9b44c6e-124c-4e68-bb8f-f0d68a3a3391)


