### PR TITLE
Add the Source of the Related Concepts

### DIFF
--- a/pages/orgs/[org]/sources/[source]/concepts/[concept]/index.js
+++ b/pages/orgs/[org]/sources/[source]/concepts/[concept]/index.js
@@ -716,6 +716,9 @@ function ConceptDetail() {
                   <TableCell sx={{ textTransform: "uppercase" }}>
                     Concept
                   </TableCell>
+                  <TableCell sx={{ textTransform: "uppercase" }}>
+                    Source
+                  </TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
@@ -754,6 +757,14 @@ function ConceptDetail() {
                               })}
                             </details>
                           )}
+                        </TableCell>
+                        <TableCell>
+                          <Link
+                            href={`/orgs/${org}/sources/${source}`}
+                            style={{ textDecoration: "none" }}
+                          >
+                            {source}
+                          </Link>
                         </TableCell>
                       </TableRow>
                     );

--- a/pages/orgs/[org]/sources/[source]/concepts/[concept]/index.js
+++ b/pages/orgs/[org]/sources/[source]/concepts/[concept]/index.js
@@ -71,7 +71,12 @@ function ConceptDetail() {
   const handleChangePage = (event, newPage) => {
     setPage(newPage);
   };
-
+  const [isClicked, setIsClicked] = useState(false);
+  const handleCopyLinkClick = () => {
+    handleCopyLink(org, source, conceptDetail);
+    setIsClicked(true);
+    setTimeout(() => setIsClicked(false), 3000);
+  };
   const handleChangeRowsPerPage = (event) => {
     setRowsPerPage(parseInt(event.target.value, 10));
     setPage(0);
@@ -189,13 +194,19 @@ function ConceptDetail() {
                 edge="end"
                 aria-label="copy link"
                 size="small"
-                onClick={() => {
-                  handleCopyLink(org, source, conceptDetail);
-                }}
+                onClick={handleCopyLinkClick}
               >
                 <ContentCopyIcon fontSize="small" />
               </IconButton>
-              <Typography variant="body2" color="#FF5733" ml={1}>
+              <Typography
+                variant="body2"
+                ml={1}
+                onClick={handleCopyLinkClick}
+                style={{
+                  cursor: "pointer",
+                  color: isClicked ? "#4CAF50" : "#FF5733",
+                }}
+              >
                 Copy Link
               </Typography>
             </Box>


### PR DESCRIPTION
This PR ensures that;
1. The Source  column is included in the `Related Concepts`   I have attached a screenshot and circle the part introduced in the UI
2. The link for the copy action is functioning while viewing a concept. 

![image](https://github.com/user-attachments/assets/77034195-3c4f-4078-83dc-814d1a54cbfa)

[Screencast from 2024-09-05 09-35-42.webm](https://github.com/user-attachments/assets/a39fb566-44f0-44ca-8db1-74b30b41a61c)


