### PR TITLE
ensure we have no 404 error and also limit upload size

### DIFF
--- a/pages/auth/index.js
+++ b/pages/auth/index.js
@@ -1,0 +1,12 @@
+export async function getServerSideProps() {
+  return {
+    redirect: {
+      destination: "/",
+      permanent: false,
+    },
+  };
+}
+
+const AuthIndex = () => null;
+
+export default AuthIndex;

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -39,7 +39,15 @@ function ResourcesKnhts() {
 
   const handleFileSelect = (event) => {
     const filesArray = Array.from(event.target.files);
-    setSelectedFiles([...selectedFiles, ...filesArray]);
+    const filteredFiles = filesArray.filter(
+      (file) => file.size <= 5 * 1024 * 1024
+    );
+
+    if (filesArray.length !== filteredFiles.length) {
+      alert("This file exceeds the maximum allowed size of 5MB.");
+    }
+
+    setSelectedFiles([...selectedFiles, ...filteredFiles]);
   };
 
   const handleFileUpload = () => {


### PR DESCRIPTION
This PR ensures that:
1. no error 404 when accessing some pages
2. limit resource upload size to 5 Mb per upload.

[screencast-from-2024-09-16-15-48-10_P6thCpiH.webm](https://github.com/user-attachments/assets/ff9740ed-c999-46b4-9425-8811bee56c22)
